### PR TITLE
No mutation

### DIFF
--- a/index.js
+++ b/index.js
@@ -37,7 +37,7 @@ module.exports = function except(obj, keys) {
     var value = result[first];
 
     if (isObject(value) && parts.length > 0) {
-      except(result[first], parts);
+      result = except(result[first], parts);
       if (isObject(result[first]) && !Object.keys(result[first]).length) {
         delete result[first];
       }

--- a/index.js
+++ b/index.js
@@ -5,6 +5,7 @@
  */
 
 var isObject = require('is-object');
+var clone = require('clone');
 
 /**
  * Pick values from object except the given keys.
@@ -28,20 +29,22 @@ module.exports = function except(obj, keys) {
     throw new Error('`keys` should be array');
   }
 
+  var result = clone(obj);
+
   for (var i = 0, l = keys.length; i < l; i++) {
     var parts = keys[i].split('.');
     var first = parts.shift();
-    var value = obj[first];
+    var value = result[first];
 
     if (isObject(value) && parts.length > 0) {
-      except(obj[first], parts);
-      if (isObject(obj[first]) && !Object.keys(obj[first]).length) {
-        delete obj[first];
+      except(result[first], parts);
+      if (isObject(result[first]) && !Object.keys(result[first]).length) {
+        delete result[first];
       }
     } else {
-      delete obj[first];
+      delete result[first];
     }
   }
 
-  return obj;
+  return result;
 };

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "property"
   ],
   "dependencies": {
+    "clone": "^1.0.2",
     "is-object": "^1.0.1"
   },
   "devDependencies": {

--- a/test.js
+++ b/test.js
@@ -39,6 +39,18 @@ test('should get properties from object', function (t) {
 	t.equal(0, Object.keys(res).length);
 });
 
+test('shouldn’t mutate the object', function (t) {
+	t.plan(2);
+
+	var obj = {
+		foo: 'bar',
+		bar: 'foo'
+	};
+
+	t.deepEqual(objectExcept(obj, 'foo'), {bar: 'foo'});
+	t.deepEqual(obj, {foo: 'bar', bar: 'foo'});
+});
+
 test('should throw error with wrong arguments', function (t) {
 	t.plan(2);
 


### PR DESCRIPTION
Hi! That’s a nice little module.

There’s a good practice though that a function either returns a new value or causes side-effects – but not both. I found this a little confusing at first:

``` js
const ab = {a: 'a', b: 'b'};
const b = except(ab, 'a');

b;   //» {b: 'b'}
ab;  //» {b: 'b'}
```

I’d rather expect `ab` to stay `{a: 'a', b: 'b'}`. `b` is the new value and mutating `ab` is a side-effect.

Note that this PR is a breaking change. If you prefer to keep the behavior as it is, feel free to close this PR. I’ll just publish a new module.

Cheers!
